### PR TITLE
parse message bodies conditionally

### DIFF
--- a/js/src/datamartreport/datamartreport.js
+++ b/js/src/datamartreport/datamartreport.js
@@ -228,7 +228,7 @@
                     //If the message doesn't target the iFrame in this element, then exit
                     if (!(el.find('iframe')[0] && el.find('iframe')[0].contentWindow === e.source)) {
                         if (e.origin === 'https://www.blackbaud.com' && e.data.indexOf('bbHelpKey') > 0) {
-                            message = JSON.parse(e.data);
+                            message = angular.isString(e.data) ? JSON.parse(e.data) : e.data;
                             if (message.bbHelpKey) {
                                 bbHelp.open(message.bbHelpKey);
                             }
@@ -243,7 +243,7 @@
                         }
                     }
 
-                    message = JSON.parse(e.data);
+                    message = angular.isString(e.data) ? JSON.parse(e.data) : e.data;
                     if (message.gdc) {
                         message = message.gdc;
 


### PR DESCRIPTION
Check whether the bodies of messages from an iframe within an embedded object have already been parsed before calling JSON.parse.

This isn't super crucial, but it would fix some `Uncaught SyntaxError: Unexpected token o in JSON at position 1` errors that show up in the console in Chrome.
