### PR TITLE
Add dashboard styles to support editor view

### DIFF
--- a/js/src/datamartreport/datamartreport.js
+++ b/js/src/datamartreport/datamartreport.js
@@ -7,6 +7,14 @@
     var DASHBOARD_STYLES = {
         "dashboardStylist": {
             "skin": {
+                //Hide lock button on embedded dashboards for users in Editor role.
+                ".dashboardHeader .yui3-lockbutton": {
+                    "display": "none"
+                },
+                //Hide report flyout link on embedded dashboards.  Needed because users in Editor role see undesirable "View this report" link in the flyout.
+                ".reportInfoPanelHandle": {
+                    "display": "none !important"
+                },
                 "body.white": {
                     "background": "#f3f3f4"
                 },


### PR DESCRIPTION
This adds styles to embedded dashboards to hide the lock icon that
displays when the user has the Editor role, as well as hiding the flyout
link above reports.  In order to support embedding Analytical Designer,
users must be in the Editor role.  When they are in the Editor role,
they see an undesirable link to "View this report" in that flyout that
takes them to the report editor view.
