### PR TITLE
Add back report action flyout on dashboards

### DIFF
--- a/js/src/datamartreport/datamartreport.js
+++ b/js/src/datamartreport/datamartreport.js
@@ -11,10 +11,6 @@
                 ".dashboardHeader .yui3-lockbutton": {
                     "display": "none"
                 },
-                //Hide report flyout link on embedded dashboards.  Needed because users in Editor role see undesirable "View this report" link in the flyout.
-                ".reportInfoPanelHandle": {
-                    "display": "none !important"
-                },
                 "body.white": {
                     "background": "#f3f3f4"
                 },


### PR DESCRIPTION
No longer hiding the report action flyout on dashboards.  It was decided
that having the download as button is too important.  Other options will
be explored for hiding undesirable action buttons individually, such as
improved roles.
