### PR TITLE
Fix issue with browser history

### DIFF
--- a/js/src/datamartreport/datamartreport.js
+++ b/js/src/datamartreport/datamartreport.js
@@ -188,9 +188,9 @@
                         });
                     }
 
-                    $scope.$watch('embeddedObjectId', setiFrameUrl);
+                    $scope.$watch('embeddedObjectId', resetiFrameUrl);
 
-                    $scope.$watch('filters', setiFrameUrl, true);
+                    $scope.$watch('filters', resetiFrameUrl, true);
 
                     setiFrameUrl();
                     

--- a/js/src/datamartreport/test/datamartreport.spec.js
+++ b/js/src/datamartreport/test/datamartreport.spec.js
@@ -135,12 +135,15 @@
             $scope.scopeReportId = REPORT_ID_1;
 
             $scope.$digest();
+            $timeout.flush();
 
             expect(el.find('iframe').length).toBe(1);
             expect(el.find('iframe').attr('src')).toBe(formatReportFrameUrl(REPORT_PATH_1));
 
             //Changing the report ID should update the iframe URL
             $scope.scopeReportId = REPORT_ID_2;
+            $scope.$digest();
+            $timeout.flush();
             $scope.$digest();
             expect(el.find('iframe').attr('src')).toBe(formatReportFrameUrl(REPORT_PATH_2));
         });
@@ -155,6 +158,7 @@
             $scope.scopeReportId = REPORT_ID_1;
 
             $scope.$digest();
+            $timeout.flush();
 
             expect(el.find('iframe').attr('src')).toBe(formatReportFrameUrl(REPORT_PATH_1));
 
@@ -173,6 +177,7 @@
             $scope.scopeReportId = REPORT_ID_1;
 
             $scope.$digest();
+            $timeout.flush();
 
             expect(el.find('iframe').length).toBe(1);
 
@@ -196,7 +201,8 @@
             $scope.scopeReportId = REPORT_ID_1;
 
             $scope.$digest();
-
+            $timeout.flush();
+            
             frame = el.find('iframe');
 
             expect(frame.length).toBe(1);


### PR DESCRIPTION
When updating the iFrame URL, it causes browsers to add the page a
second time into the browser history. When a number reports are embedded
on the page, updating a filter across them can add lots of false entries
into the browser history.  This change will remove the iFrame and add it
back with the new URL rather than navigate the URL of the existing
iFrame.
